### PR TITLE
See description

### DIFF
--- a/package-dry.json
+++ b/package-dry.json
@@ -4,7 +4,7 @@
   "description": "OoT Randomizer's Multiworld implemented as a ModLoader64 plugin.", 
   "main": "Multiworld.json", 
   "author": "DemoXin", 
-  "credits": "", 
+  "credits": "TheLensta", 
   "license": "MIT", 
   "core": "ocarinaoftime", 
   "dry": { 

--- a/src/Multiworld/src/Main.ts
+++ b/src/Multiworld/src/Main.ts
@@ -88,7 +88,7 @@ export class Multiworld implements IPlugin
         if(this.protocol == undefined) { return; }
         if(!this.protocol.hasOutgoingItem()) { return; }
 
-        var outgoingItem: Item = this.protocol.getOutgoingItem(true);
+        var outgoingItem: Item = this.protocol.getOutgoingItem();
 
         this.cDB.othersItems.push(outgoingItem);
 

--- a/src/Multiworld/src/Protocol/IProtocol.ts
+++ b/src/Multiworld/src/Protocol/IProtocol.ts
@@ -61,7 +61,7 @@ export interface IProtocol
      * @returns {Item} An Item representing the Outbound Item
      * @memberof IProtocol
      */
-    getOutgoingItem(clear: boolean) : Item;
+    getOutgoingItem() : Item;
     /**
      * Set the Outbound Item in RAM.  You probably shouldn't do this!
      *

--- a/src/Multiworld/src/Protocol/Protocolv0.ts
+++ b/src/Multiworld/src/Protocol/Protocolv0.ts
@@ -104,19 +104,16 @@ export class Protocolv0 implements IProtocol
     {
         return this.emulator.rdramRead32(this.outgoingKeyAddr) != 0;
     }
-    getOutgoingItem(clear: boolean): Item
+    getOutgoingItem(): Item
     {
         var itemId: number = this.emulator.rdramRead16(this.outgoingItemAddr);
         var receivingPlayer: number = this.emulator.rdramRead16(this.outgoingPlayerAddr);
         var myPlayer: number = this.getPlayerID();
         var outgoingItem: Item = new Item(myPlayer, receivingPlayer, itemId);
 
-        if(clear)
-        {
-            this.emulator.rdramWrite32(this.outgoingKeyAddr, 0);
-            this.emulator.rdramWrite16(this.outgoingItemAddr, 0);
-            this.emulator.rdramWrite16(this.outgoingPlayerAddr, 0);
-        }
+        this.emulator.rdramWrite32(this.outgoingKeyAddr, 0);
+        this.emulator.rdramWrite16(this.outgoingItemAddr, 0);
+        this.emulator.rdramWrite16(this.outgoingPlayerAddr, 0);
 
         return outgoingItem;
     }
@@ -134,7 +131,7 @@ export class Protocolv0 implements IProtocol
     getIncomingItem(): Item
     {
         var itemId: number = this.emulator.rdramRead16(this.incomingItemAddr);
-        return new Item(this.getPlayerID(), this.getPlayerID(), itemId);
+        return new Item(this.getPlayerID(), this.getPlayerID(), itemId); //I'm not sure why there's 2 getPlayerID()'s here
     }
     setIncomingItem(item: Item): void
     {

--- a/src/Multiworld/src/Protocol/Protocolv2.ts
+++ b/src/Multiworld/src/Protocol/Protocolv2.ts
@@ -22,16 +22,19 @@ export class Protocolv2 extends Protocolv1
 
     getProtocolVersion(): number { return 2; }
 
-    getIncomingItem(): Item
+    getIncomingItem(): Item //Only used in boolean safety check, returning itemId does suffice
     {
         var itemId: number = this.emulator.rdramRead16(this.incomingItemAddr);
+        /*
         var sendingPlayer: number = this.emulator.rdramRead16(this.incomingPlayerAddr);
         return new Item(sendingPlayer, this.getPlayerID(), itemId);
+        */
+        return itemId;
     }
 
     setIncomingItem(item: Item): void
     {
-        this.emulator.rdramWrite16(this.incomingPlayerAddr, item.sendingPlayer);
+        this.emulator.rdramWrite16(this.incomingPlayerAddr, item.receivingPlayer);
         this.emulator.rdramWrite16(this.incomingItemAddr, item.itemId);
     }
 }

--- a/src/Multiworld/src/Protocol/Protocolv2.ts
+++ b/src/Multiworld/src/Protocol/Protocolv2.ts
@@ -22,14 +22,11 @@ export class Protocolv2 extends Protocolv1
 
     getProtocolVersion(): number { return 2; }
 
-    getIncomingItem(): Item //Only used in boolean safety check, returning itemId does suffice
+    getIncomingItem(): Item
     {
         var itemId: number = this.emulator.rdramRead16(this.incomingItemAddr);
-        /*
         var sendingPlayer: number = this.emulator.rdramRead16(this.incomingPlayerAddr);
         return new Item(sendingPlayer, this.getPlayerID(), itemId);
-        */
-        return itemId;
     }
 
     setIncomingItem(item: Item): void


### PR DESCRIPTION
These are most of the changes I did to get protocolv2 working, I've missed out a few extra things I removed as I wouldn't want to remove additional compatibility for no reason.

These are:
 - Removing getIncomingItem() from protocolv0
 - Removing setIncomingItem() from protocol v0

Those two functions share the same function name in protocolv2 and each protocol extends each other, I was concerned that in main.ts whenever these functions are called they could execute in protocolv0 instead of protocolv2 or both.

I have left additional comments to look over that don't need merging but just fyi's